### PR TITLE
Fix navigation crashes caused by unencoded route string arguments

### DIFF
--- a/presentation/src/main/java/site/dogether/presentation/screen/certificate/member_cert_info/MemberCertInfoViewModel.kt
+++ b/presentation/src/main/java/site/dogether/presentation/screen/certificate/member_cert_info/MemberCertInfoViewModel.kt
@@ -1,5 +1,6 @@
 package site.dogether.presentation.screen.certificate.member_cert_info
 
+import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.toImmutableList
@@ -28,7 +29,7 @@ class MemberCertInfoViewModel(
     }
 
     private val name: String by lazy {
-        savedStateHandle.get<String>(KEY_MEMBER_NAME).orEmpty()
+        Uri.decode(savedStateHandle.get<String>(KEY_MEMBER_NAME).orEmpty())
     }
 
     init {

--- a/presentation/src/main/java/site/dogether/presentation/screen/certificate/my_cert_info/MyCertInfoScreen.kt
+++ b/presentation/src/main/java/site/dogether/presentation/screen/certificate/my_cert_info/MyCertInfoScreen.kt
@@ -1,5 +1,6 @@
 package site.dogether.presentation.screen.certificate.my_cert_info
 
+import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -76,7 +77,7 @@ fun MyCertInfoScreen(viewModel: MyCertInfoViewModel = koinViewModel()) {
     viewModel.CollectEffect<MyCertInfoUiEffect> { uiEffect ->
         when (uiEffect) {
             is MyCertInfoUiEffect.NavigateToCertificateTodo -> {
-                navHostController.navigate("${Screen.CERTIFICATE_TODO}/${uiEffect.todoId}/${uiEffect.todoTitle}")
+                navHostController.navigate("${Screen.CERTIFICATE_TODO}/${uiEffect.todoId}/${Uri.encode(uiEffect.todoTitle)}")
             }
         }
     }

--- a/presentation/src/main/java/site/dogether/presentation/screen/home/HomeScreen.kt
+++ b/presentation/src/main/java/site/dogether/presentation/screen/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package site.dogether.presentation.screen.home
 
+import android.net.Uri
 import android.app.Activity
 import android.Manifest
 import android.content.Context
@@ -171,7 +172,7 @@ fun HomeScreen(viewModel: HomeViewModel = koinViewModel()) {
             // 투두 인증 페이지로 이동
             is HomeUiEffect.NavigateToCertificateTodo -> {
                 navHostController.navigate(
-                    "${Screen.CERTIFICATE_TODO}/${uiEffect.todoId}/${uiEffect.todoTitle}"
+                    "${Screen.CERTIFICATE_TODO}/${uiEffect.todoId}/${Uri.encode(uiEffect.todoTitle)}"
                 )
             }
 

--- a/presentation/src/main/java/site/dogether/presentation/screen/ranking/RankingScreen.kt
+++ b/presentation/src/main/java/site/dogether/presentation/screen/ranking/RankingScreen.kt
@@ -1,5 +1,6 @@
 package site.dogether.presentation.screen.ranking
 
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -65,7 +66,7 @@ fun RankingScreen(viewModel: RankingViewModel = koinViewModel()) {
         uiState = viewModel.collectAsState().value,
         onEvent = { uiEvent -> viewModel.onEvent(uiEvent) },
         onNavigateToMemberCertInfo = { groupId, memberId, memberName ->
-            navHostController.navigate("${Screen.MEMBER_CERT_INFO}/$groupId/$memberId/$memberName")
+            navHostController.navigate("${Screen.MEMBER_CERT_INFO}/$groupId/$memberId/${Uri.encode(memberName)}")
         }
     )
 }

--- a/presentation/src/main/java/site/dogether/presentation/screen/todo/certificate/CertificateTodoViewModel.kt
+++ b/presentation/src/main/java/site/dogether/presentation/screen/todo/certificate/CertificateTodoViewModel.kt
@@ -15,7 +15,7 @@ class CertificateTodoViewModel(savedStateHandle: SavedStateHandle) : BaseViewMod
     }
 
     val todoTitle: String by lazy {
-        savedStateHandle.get<String>(KEY_TODO_TITLE).orEmpty()
+        Uri.decode(savedStateHandle.get<String>(KEY_TODO_TITLE).orEmpty())
     }
 
     override fun onEvent(event: UiEvent) {


### PR DESCRIPTION
### Motivation
- Navigation routes broke when user-provided strings (like todo titles or member names) contained reserved characters such as `/`, `?`, `#`, or spaces, causing runtime navigation errors. 
- The intent is to make route construction robust by encoding strings when navigating and decoding them in the receiving ViewModels so the UI still sees the original text.

### Description
- Encode `todoTitle` with `Uri.encode(...)` when navigating to `CERTIFICATE_TODO` from `HomeScreen` and `MyCertInfoScreen` and add the `android.net.Uri` import. 
- Encode `memberName` with `Uri.encode(...)` when navigating to `MEMBER_CERT_INFO` from `RankingScreen` and add the `android.net.Uri` import. 
- Decode `KEY_TODO_TITLE` with `Uri.decode(...)` in `CertificateTodoViewModel` so the ViewModel receives the original title and add the `android.net.Uri` import. 
- Decode `KEY_MEMBER_NAME` with `Uri.decode(...)` in `MemberCertInfoViewModel` so the ViewModel receives the original name and add the `android.net.Uri` import. 

### Testing
- Ran `./gradlew :presentation:compileDebugKotlin`, which failed because the Android SDK location is not configured in this environment (`sdk.dir`/`ANDROID_HOME` missing). 
- Ran `./gradlew :domain:test`, which failed due to external dependency downloads being blocked (HTTP 403 from configured Maven repos). 
- Confirmed the code edits and committed the changes locally (files modified: `HomeScreen.kt`, `MyCertInfoScreen.kt`, `RankingScreen.kt`, `CertificateTodoViewModel.kt`, `MemberCertInfoViewModel.kt`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699586d4e6f8832c876ba26ce8c8b2cb)